### PR TITLE
Fix compile errors on Darwin

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -43,7 +43,7 @@ AM_CONDITIONAL([HAVE_PDFLATEX], test -n "$PDFLATEX")
 
 
 dnl inspired by rsync's configure.ac
-AC_CHECK_FUNCS(fchmod setmode open64 mkstemp64)
+AC_CHECK_FUNCS(fchmod setmode open64 mkstemp64 strlcpy)
 AC_CACHE_CHECK([for secure mkstemp],csync_cv_HAVE_SECURE_MKSTEMP,[
 AC_TRY_RUN([#include <stdlib.h>
 #include <sys/types.h>

--- a/configure.ac
+++ b/configure.ac
@@ -43,7 +43,7 @@ AM_CONDITIONAL([HAVE_PDFLATEX], test -n "$PDFLATEX")
 
 
 dnl inspired by rsync's configure.ac
-AC_CHECK_FUNCS(fchmod setmode open64 mkstemp64 strlcpy)
+AC_CHECK_FUNCS(fchmod setmode open64 mkstemp64 strlcpy get_current_dir_name)
 AC_CACHE_CHECK([for secure mkstemp],csync_cv_HAVE_SECURE_MKSTEMP,[
 AC_TRY_RUN([#include <stdlib.h>
 #include <sys/types.h>

--- a/conn.c
+++ b/conn.c
@@ -281,7 +281,7 @@ int conn_activate_ssl(int server_role)
 		return 0;
 
 	ASPRINTF(&ssl_keyfile, "%s/csync2_ssl_key.pem", systemdir);
-	ASPRINTF(&ssl_certfile, "%s/csync_ssl_cert.pem", systemdir);
+	ASPRINTF(&ssl_certfile, "%s/csync2_ssl_cert.pem", systemdir);
 
 	gnutls_global_init();
 	gnutls_global_set_log_function(ssl_log);

--- a/db.c
+++ b/db.c
@@ -36,7 +36,7 @@ int db_sync_mode = 1;
 extern int db_type; 
 static db_conn_p db = 0;
 // TODO make configurable
-int wait = 1;
+static int db_wait = 1;
 
 static int get_dblock_timeout()
 {
@@ -106,9 +106,9 @@ void csync_db_maycommit()
 
 	if ((now - last_wait_cycle) > 10) {
 		SQL("COMMIT", "COMMIT ");
-		if (wait) {
-		  csync_debug(2, "Waiting %d secs so others can lock the database (%d - %d)...\n", wait, (int)now, (int)last_wait_cycle);
-		  sleep(wait);
+		if (db_wait) {
+		  csync_debug(2, "Waiting %d secs so others can lock the database (%d - %d)...\n", db_wait, (int)now, (int)last_wait_cycle);
+		  sleep(db_wait);
 		}
 		last_wait_cycle = 0;
 		tqueries_counter = -10;

--- a/getrealfn.c
+++ b/getrealfn.c
@@ -28,7 +28,7 @@
 
 static char *my_get_current_dir_name()
 {
-#if defined __CYGWIN__ || defined __FreeBSD__ || defined __OpenBSD__ || defined __NetBSD__
+#ifndef HAVE_GET_CURRENT_DIR_NAME
 	char *r = malloc(1024);
 	if (!getcwd(r, 1024))
 		strcpy(r, "/__PATH_TO_LONG__");

--- a/rsync.c
+++ b/rsync.c
@@ -49,6 +49,7 @@
  *
  * @return index of the terminating byte.
  **/
+#ifndef HAVE_STRLCPY
 static size_t strlcpy(char *d, const char *s, size_t bufsize)
 {
         size_t len = strlen(s);
@@ -61,6 +62,7 @@ static size_t strlcpy(char *d, const char *s, size_t bufsize)
         }
         return ret;
 }
+#endif
 
 /* splits filepath at the last '/', if any, like so:
  *	dirname		basename	filepath


### PR DESCRIPTION
Several compile errors occur on Darwin/OS X. Those errors are due to :
- functions present in Darwin that are absent from Gnulib (`strlcpy`, `wait`)
- functions present in Gnulib that are absent from Darwin (`get_current_dir_name`)

Also, there's a typo in the certificate's filename.
